### PR TITLE
Bugfix: duration of wav

### DIFF
--- a/lib/audioinfo.rb
+++ b/lib/audioinfo.rb
@@ -198,7 +198,7 @@ class AudioInfo
 
       when 'wav'
         @info = WaveFile::Reader.info(filename)
-        @length = @info.duration.hours * 3600 + @info.duration.minutes * 60 + @info.duration.seconds + @info.duration.milliseconds * 0.01
+        @length = @info.duration.hours * 3600 + @info.duration.minutes * 60 + @info.duration.seconds + @info.duration.milliseconds * 0.001
         @bitrate = File.size(filename) * 8 / @length / 1024
 
       else


### PR DESCRIPTION
This bug can be reproduced when input wav is greater than 1 minutes.

e.g.
- If an input file is 70 seconds, `@info.duration.seconds` returns 10.
- In this case, we have to add `@info.duration.minutes * 60` to it.

wavefile API doc is:
http://wavefilegem.com/doc/WaveFile/Duration.html