### PR TITLE
Fix wavefile dependency

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -1,6 +1,7 @@
 === 0.5.3 / 2016-03-
 
 * added format parameter
+* fix wavefile gem version to `~> 0.6.0`
 
 === 0.5.2 / 2016-01-05
 

--- a/lib/audioinfo.rb
+++ b/lib/audioinfo.rb
@@ -13,6 +13,7 @@ $LOAD_PATH << File.expand_path(File.dirname(__FILE__))
 
 require 'audioinfo/mpcinfo'
 require 'audioinfo/case_insensitive_hash'
+require 'audioinfo/version'
 
 class AudioInfoError < StandardError; end
 
@@ -29,8 +30,6 @@ class AudioInfo
   }.freeze
 
   SUPPORTED_EXTENSIONS = %w(mp3 ogg opus spx mpc wma mp4 aac m4a flac wav).freeze
-
-  VERSION = '0.5.3'.freeze
 
   attr_reader :path, :extension, :musicbrainz_infos, :tracknum, :bitrate, :vbr
   attr_reader :artist, :album, :title, :length, :date

--- a/lib/audioinfo/version.rb
+++ b/lib/audioinfo/version.rb
@@ -1,0 +1,3 @@
+class AudioInfo
+  VERSION = '0.5.3'.freeze
+end

--- a/ruby-audioinfo.gemspec
+++ b/ruby-audioinfo.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |s|
   s.name = "ruby-audioinfo"
-  s.version = "0.5.0"
+  s.version = AudioInfo::VERSION
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Guillaume Pierronnet", "Marcello Barnaba"]
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency(%q<moumar-wmainfo-rb>, [">= 0.7"])
   s.add_runtime_dependency(%q<flacinfo-rb>, [">= 0.4"])
   s.add_runtime_dependency(%q<apetag>, [">= 1.1.4"])
-  s.add_runtime_dependency(%q<wavefile>, [">= 0.6.0"])
+  s.add_runtime_dependency(%q<wavefile>, ["~> 0.6.0"])
   s.add_development_dependency(%q<rdoc>, ["~> 3.10"])
   s.add_development_dependency(%q<hoe>, ["~> 3.5"])
 end

--- a/ruby-audioinfo.gemspec
+++ b/ruby-audioinfo.gemspec
@@ -1,6 +1,10 @@
 # -*- encoding: utf-8 -*-
 # stub: ruby-audioinfo 0.3.3.20131025192033 ruby lib
 
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'audioinfo/version'
+
 Gem::Specification.new do |s|
   s.name = "ruby-audioinfo"
   s.version = AudioInfo::VERSION
@@ -10,16 +14,17 @@ Gem::Specification.new do |s|
   s.date = "2013-10-25"
   s.description = "ruby-audioinfo glue together various audio ruby libraries and presents a unified\nAPI to the developper. Currently, supported formats are: mp3, ogg, mpc, ape,\nwma, flac, aac, mp4, m4a."
   s.email = ["guillaume.pierronnet@gmail.com", "unknown"]
-  s.extra_rdoc_files = ["History.txt", "Manifest.txt", "README.rdoc", "README.rdoc"]
-  s.files = ["History.txt", "Manifest.txt", "README.rdoc", "Rakefile", "lib/audioinfo.rb", "lib/audioinfo/album.rb", "lib/audioinfo/mpcinfo.rb", "lib/audioinfo/case_insensitive_hash.rb", "test/mpcinfo.rb", "test/test_audioinfo.rb", "test/test_case_insensitive_hash.rb", "test/test_helper.rb"]
   s.homepage = "http://ruby-audioinfo.rubyforge.org"
   s.rdoc_options = ["--main", "README.rdoc"]
-  s.require_paths = ["lib"]
+  s.extra_rdoc_files = ["History.txt", "Manifest.txt", "README.rdoc", "README.rdoc"]
   s.rubyforge_project = "ruby-audioinfo"
   s.rubygems_version = "2.1.5"
   s.summary = "ruby-audioinfo glue together various audio ruby libraries and presents a unified API to the developper"
-  s.test_files = ["test/test_audioinfo.rb", "test/test_case_insensitive_hash.rb", "test/test_helper.rb"]
   s.license = 'GPL-3.0'
+
+  s.files = `git ls-files -z`.split("\x0")
+  s.test_files = s.files.grep(%r{^(test|spec|features)/})
+  s.require_paths = ["lib"]
 
   s.add_runtime_dependency(%q<ruby-mp3info>, [">= 0.8"])
   s.add_runtime_dependency(%q<ruby-ogginfo>, [">= 0.6.13"])

--- a/test/test_wav.rb
+++ b/test/test_wav.rb
@@ -21,7 +21,7 @@ class TestWav < MiniTest::Unit::TestCase
 
   def test_wav_length
     i = AudioInfo.new(WAV_FILE)
-    assert_equal i.length, 6
+    assert_equal i.length, 6.306
   end
 
 end


### PR DESCRIPTION
`wavefile` dependency has been updated with breaking changes. 

> * Reader.info() has been removed. Instead, construct a new Reader instance and use Reader.native_format() - this will return a Format instance with the same info that would have been returned by Reader.info().
> * Similarly, the Info class has been removed, due to Reader.info() being removed.

https://github.com/jstrait/wavefile/tree/v0.7.0#current-release-v070

`Reader.info()` and the new `Format` object does not have exactly the same interface, hence I have not updated to `wavefile 0.7.0` as I'm not sure if that would break someone else code as `AudioInfo` exposes `@info` as a public reader.

This PR also:
* fixes a broken test (wav file duration).
* extract the gem version into its own file and updates the gemspec to use the specified gem version in the version file.
* defines the list of files to be included in the gemspec from git information.   

