### PR TITLE
Do not truncate fractional audio lengths

### DIFF
--- a/lib/audioinfo.rb
+++ b/lib/audioinfo.rb
@@ -97,7 +97,7 @@ class AudioInfo
         @bitrate = @info.bitrate
         i = @info.tag.tracknum
         @tracknum = (i.is_a?(Array) ? i.last : i).to_i
-        @length = @info.length.to_i
+        @length = @info.length.to_f
         @date = @info.tag['date']
         @vbr = @info.vbr
         @info.close
@@ -108,7 +108,7 @@ class AudioInfo
         default_tag_fill
         @bitrate = @info.bitrate / 1000
         @tracknum = @info.tag.tracknumber.to_i
-        @length = @info.length.to_i
+        @length = @info.length.to_f
         @date = @info.tag['date']
         @vbr = true
         @info.close


### PR DESCRIPTION
mp3, ogg, opus, and spx readers capture fractional lengths of audio files, but the code casts these to integers which drops the sub-second values.  This PR changes the `to_i` calls to `to_f` to keep the floating point parts of lengths.  

Pushing to test as I don't have the required libraries installed.